### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@ questions.
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>2.1.1-SNAPSHOT</version>
+            <version>2.2.5</version>
         </dependency>
         <dependency>
             <groupId>com.jolbox</groupId>


### PR DESCRIPTION
The project doesn't build. com.zaxxer.HikariCP:2.1.1-SNAPSHOT is not available in public maven repository. Use the latest release version

 <dependency>
            <groupId>com.zaxxer</groupId>
            <artifactId>HikariCP</artifactId>
            <version>2.2.5</version>   ->   <version>2.2.5</version> 
 </dependency>